### PR TITLE
Fix defaults not using false

### DIFF
--- a/src/yeelight.js
+++ b/src/yeelight.js
@@ -21,7 +21,7 @@ function YeelightPlatform(log, config = {}, api) {
   this.config = config
   this.debug = this.config.debug || false
   this.addResetSwitch = (typeof this.config.addResetSwitch === 'undefined') ? true : this.config.addResetSwitch
-  this.shouldTurnOff = this.config.shouldTurnOff || true
+  this.shouldTurnOff = (typeof this.config.shouldTurnOff === 'undefined') ? true : this.config.shouldTurnOff
   this.lights = {}
   this.switches = {}
   this.resetSwitch = null

--- a/src/yeelight.js
+++ b/src/yeelight.js
@@ -20,7 +20,7 @@ function YeelightPlatform(log, config = {}, api) {
   this.log = log
   this.config = config
   this.debug = this.config.debug || false
-  this.addResetSwitch = this.config.addResetSwitch || true
+  this.addResetSwitch = (typeof this.config.addResetSwitch === 'undefined') ? true : this.config.addResetSwitch
   this.shouldTurnOff = this.config.shouldTurnOff || true
   this.lights = {}
   this.switches = {}


### PR DESCRIPTION
Using || made it so it will always default to true. That way `addResetSwitch` and `shouldTurnOff` were not set to false.
Fixed it by using typeof.